### PR TITLE
Adding two-part objective

### DIFF
--- a/resume.yaml
+++ b/resume.yaml
@@ -1,5 +1,8 @@
 basics:
   name: Paul Bruno
+  objective:
+    role: Staff-Level Engineer & Tech/Team Lead
+    realm: Front End Specialist & Full Stack Generalist
   summary: |
     I'm a builder at heart, aimed at making what matters: well-built software and great teams. Over
     **14 yrs.** experience (**10 yrs. remotely**) as an engineer/architect designing and


### PR DESCRIPTION
`role`/`realm` end up being (presentationally) heading/subheading.